### PR TITLE
♻️ refactor : lazy loading#150

### DIFF
--- a/server/src/main/java/com/gallendar/gradle/server/board/entity/Board.java
+++ b/server/src/main/java/com/gallendar/gradle/server/board/entity/Board.java
@@ -30,7 +30,7 @@ public class Board extends BaseTimeEntity {
     @OneToMany(mappedBy = "board", cascade = CascadeType.REMOVE)
     private List<BoardTags> boardTags;
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "members_id")
     private Members members;
 

--- a/server/src/main/java/com/gallendar/gradle/server/tags/controller/TagsController.java
+++ b/server/src/main/java/com/gallendar/gradle/server/tags/controller/TagsController.java
@@ -25,7 +25,7 @@ public class TagsController {
     /**
      * 태그 알림 요청
      *
-     * @param id
+     * @param userId
      * @return
      */
     @ApiOperation(value = "태그 알림", notes = "현재 로그인 한 유저의 태그된 게시글에 대한 정보를 간단히 응답한다.")

--- a/server/src/main/java/com/gallendar/gradle/server/tags/domain/BoardTags.java
+++ b/server/src/main/java/com/gallendar/gradle/server/tags/domain/BoardTags.java
@@ -13,11 +13,11 @@ public class BoardTags {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "board_id")
     private Board board;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "tags_id")
     private Tags tags;
 

--- a/server/src/main/java/com/gallendar/gradle/server/tags/service/NotificationService.java
+++ b/server/src/main/java/com/gallendar/gradle/server/tags/service/NotificationService.java
@@ -31,6 +31,7 @@ public class NotificationService {
     private final BoardRepository boardRepository;
     private final MembersRepository membersRepository;
 
+    @Transactional
     public List<NotificationResponse> tagsFindById(String userId) {
         List<NotificationResponse> list = new ArrayList<>();
         List<Tags> tags = tagsRepositoryCustom.findByTagsMember(userId);


### PR DESCRIPTION
1. 연관 관계에서 일단 사용하지 않는 엔티티를 조회하는 탓에 비용 낭비가 생길 수 있고, N+1 문제가 생길 수 있다. 
* `fetch = FetchType.LAZY`  적용하였다.
* fetch join 으로 전체가 필요하다면 가져온다.