### PR TITLE
 ♻️ refactor : 연관관계 편의 메소드 수정#152

### DIFF
--- a/server/src/main/java/com/gallendar/gradle/server/board/entity/Board.java
+++ b/server/src/main/java/com/gallendar/gradle/server/board/entity/Board.java
@@ -1,5 +1,6 @@
 package com.gallendar.gradle.server.board.entity;
 
+import com.gallendar.gradle.server.category.domain.Category;
 import com.gallendar.gradle.server.global.auditing.BaseTimeEntity;
 import com.gallendar.gradle.server.members.domain.Members;
 import com.gallendar.gradle.server.tags.domain.BoardTags;
@@ -33,6 +34,10 @@ public class Board extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "members_id")
     private Members members;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="category_id")
+    private Category category;
 
     @Builder
     public Board(String title, String content, String music) {

--- a/server/src/main/java/com/gallendar/gradle/server/tags/domain/BoardTags.java
+++ b/server/src/main/java/com/gallendar/gradle/server/tags/domain/BoardTags.java
@@ -22,10 +22,18 @@ public class BoardTags {
     private Tags tags;
 
     public void setTags(Tags tags) {
+        if(this.tags!=null){
+            this.tags.getBoardTags().remove(this);
+        }
         this.tags = tags;
+        tags.getBoardTags().add(this);
     }
 
     public void setBoard(Board board) {
+        if(this.board!=null){
+            this.board.getBoardTags().remove(this);
+        }
         this.board = board;
+        board.getBoardTags().add(this);
     }
 }


### PR DESCRIPTION
1. 연관관계의 주인에는 값을 입력하지 않고, 주인이 아닌 곳에만 값을 입력하는 실수를 방지

* 객체 관점에서 양쪽 방향에 모두 값을 입력해주는 것이 안전하다.
* 기존 코드에서 관계의 데이터 삭제나 수정이 있을 경우 기존 연결되어 있는 관계를 제거하지 않았다.
* 기존 관계를 제거하는 코드를 추가 하였다.