### PR TITLE
✨ Feature/yw/tailwind.config색 추가 인증페이지 외곽구현중/ #82

### DIFF
--- a/client/components/CertifyPageLayout.tsx
+++ b/client/components/CertifyPageLayout.tsx
@@ -1,0 +1,31 @@
+import Image from "next/image";
+
+const CertifyPageLayout = (props : {
+    children : React.ReactNode
+}) => {
+
+    return (
+        <>
+    
+            <div className="flex flex-col justify-center md:justify-evenly lg:justify-center bg-bgGray items-center  h-screen">
+                <Image
+                className=""
+                    src="/images/logo export(orange).svg"
+                    width={200}
+                    height={50}
+                />
+                <div className="flex h-4/5 w-80 lg:mt-11 lg:mb-10 lg:h-[32rem] md:w-4/6 lg:w-3/5 drop-shadow-2xl">
+                    <div className="lg:w-1/2 hidden md:hidden lg:block h-full bg-amber-300">
+                        {/* <div className="absolute top-0 bottom-0 left-0 right-0 w-full h-screen bg-white/60"></div> */}
+                        <img></img>
+                        <div className=""></div>
+                    </div>
+                    <div className="w-full p-8 lg:w-1/2  h-full bg-bgWhite"> {props.children} </div>
+                </div>
+            </div>
+        </>
+    )
+
+}
+
+export default CertifyPageLayout;

--- a/client/components/scrollImg.tsx
+++ b/client/components/scrollImg.tsx
@@ -28,13 +28,13 @@ const ScrollImg = () => {
         <>
             <div id="box" className="w-full z-40 text-base flex items-center justify-center bottom-5 fixed">
                 <span className="absolute animate-ping flex h-10 w-10 rounded-full bg-orange opacity-75"></span>
-                <svg className="h-5 md:h-6 lg:h-7 fill-none text-gray-400	stroke-gray-400" viewBox="0 0 18 35" xmlns="http://www.w3.org/2000/svg">
+                <svg className="h-5 md:h-6 lg:h-7 fill-none text-white	stroke-white drop-shadow-[0_0px_3px_rgba(0,0,0,1)]" viewBox="0 0 18 35" xmlns="http://www.w3.org/2000/svg">
                     <path d="M10.7799 28.0179H7.06376C3.72819 28.0179 1 25.7215 1 22.9143V12.1314C1 9.32429 3.72886 7.02783 7.06376 7.02783H10.7792C14.1148 7.02783 16.843 9.32429 16.843 12.1314V22.9143C16.843 25.7215 14.1141 28.0179 10.7792 28.0179H10.7799Z"  stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
                     <path d="M12.4582 31.1336L8.95757 34.0803M5.42871 31.1336L8.92938 34.0803M5.42871 3.94669L8.92938 1M12.4582 3.94669L8.95757 1M8.9777 15.3939H8.86495C8.50389 15.3932 8.15787 15.2721 7.90256 15.0572C7.64725 14.8423 7.50342 14.5511 7.50254 14.2471V10.8321C7.50254 10.2016 8.11596 9.68585 8.86495 9.68585H8.9777C9.7267 9.68585 10.3401 10.2016 10.3401 10.8327V14.2483C10.3401 14.8787 9.7267 15.3951 8.9777 15.3951V15.3939Z"  stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
                 </svg>
                 <p 
                 id = "scroll-text"
-                className="ml-1 font-SCDream3 md:font-SCDream4 lg:font-SCDream5 text-[9px] md:text-sm lg:text-base text-gray-400"
+                className="ml-1 font-SCDream3 md:font-SCDream4 lg:font-SCDream5 text-[9px] md:text-sm lg:text-base text-white drop-shadow-[0_0px_5px_rgba(0,0,0,1)]"
                 > 스크롤을 내려 Gallendar에 대해서 확인하세요! </p>
             </div>
         </>

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,4 +1,4 @@
-const { RecoilBridge } = require('recoil');
+const { RecoilBridge } = require("recoil");
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
@@ -11,25 +11,26 @@ module.exports = {
   theme: {
     extend: {
       fontFamily: {
-        SCDream1 : ["SCDream1"],
-        SCDream2 : ["SCDream2"],
-        SCDream3 : ["SCDream3"],
-        SCDream4 : ["SCDream4"],
-        SCDream5 : ["SCDream5"],
-        SCDream6 : ["SCDream6"],
-        SCDream7 : ["SCDream7"],
-        SCDream8 : ["SCDream8"],
-        SCDream9 : ["SCDream9"]
+        SCDream1: ["SCDream1"],
+        SCDream2: ["SCDream2"],
+        SCDream3: ["SCDream3"],
+        SCDream4: ["SCDream4"],
+        SCDream5: ["SCDream5"],
+        SCDream6: ["SCDream6"],
+        SCDream7: ["SCDream7"],
+        SCDream8: ["SCDream8"],
+        SCDream9: ["SCDream9"],
       },
-      colors:{
-        "topbtn": "rgb(5,5,5, 0.37)",
-        "lightOrange" : "rgb(235 ,130 ,83 ,0.3)",
-        "orange" : "#EB8253",
+      colors: {
+        topbtn: "rgb(5,5,5, 0.37)",
+        lightOrange: "rgb(235 ,130 ,83 ,0.3)",
+        orange: "#EB8253",
+        bgGray: "#F8F9FD",
       },
       screens: {
-        'md': '376px'
-      }
+        md: "376px",
+      },
     },
   },
   plugins: [],
-}
+};


### PR DESCRIPTION
외곽만 일단 잡았습니다!
사용 예시코드
```
import CertifyPageLayout from "../../client/components/CertifyPageLayout"

function example() {

  return (
    <>
      <CertifyPageLayout >
        <p>뿌롱뚜 화이팅 오늘도 뿌셔뿌셔~~</p>
      </CertifyPageLayout>
    </>
  );

}

export default example;
```
tailwind.config.js에 색 추가했습니다!
```
      colors: {
        topbtn: "rgb(5,5,5, 0.37)",
        lightOrange: "rgb(235 ,130 ,83 ,0.3)",
        orange: "#EB8253",
        bgGray: "#F8F9FD", // 추가됨
        bgWhite: "#FEFEFE", //추가됨
```

![인증페이지 반응형](https://user-images.githubusercontent.com/99955022/203188311-c4f6e0c2-d208-450c-89ea-6651e37cf165.gif)

